### PR TITLE
Fabric bootstrap (Externalize Fabric)

### DIFF
--- a/MiniCraftLauncher/.classpath
+++ b/MiniCraftLauncher/.classpath
@@ -19,6 +19,5 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="lib" path="C:/Users/kingt/Documents/GitHub/file-downloader/filedownloader.jar"/>
-	<classpathentry kind="lib" path="C:/Users/kingt/Documents/GitHub/MiniGameProvider.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/MiniCraftLauncher/log.txt
+++ b/MiniCraftLauncher/log.txt
@@ -1,2 +1,0 @@
-01:43:14.729 WARN: No preferences found, creating new file.
-01:43:14.729 WARN: No unlocks found, creating new file.

--- a/MiniCraftLauncher/pom.xml
+++ b/MiniCraftLauncher/pom.xml
@@ -14,7 +14,7 @@
 	</repositories>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
-		
+
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/MiniCraftLauncher/pom.xml
+++ b/MiniCraftLauncher/pom.xml
@@ -26,57 +26,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>net.fabricmc</groupId>
-			<artifactId>access-widener</artifactId>
-			<version>2.1.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.ow2.asm</groupId>
-			<artifactId>asm</artifactId>
-			<version>9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.ow2.asm</groupId>
-			<artifactId>asm-analysis</artifactId>
-			<version>9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.ow2.asm</groupId>
-			<artifactId>asm-commons</artifactId>
-			<version>9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.ow2.asm</groupId>
-			<artifactId>asm-tree</artifactId>
-			<version>9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.ow2.asm</groupId>
-			<artifactId>asm-util</artifactId>
-			<version>9.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>net.fabricmc</groupId>
-			<artifactId>sponge-mixin</artifactId>
-			<version>0.11.1+mixin.0.8.5</version>
-		</dependency>
-		<dependency>
-			<groupId>net.fabricmc</groupId>
-			<artifactId>tiny-mappings-parser</artifactId>
-			<version>0.3.0+build.17</version>
-		</dependency>
-		<dependency>
-			<groupId>net.fabricmc</groupId>
-			<artifactId>tiny-remapper</artifactId>
-			<version>0.8.1</version>
-		</dependency>
-		<dependency>
-			<groupId>net.fabricmc</groupId>
-			<artifactId>fabric-loader</artifactId>
-			<version>0.13.0</version>
-		</dependency>
-	</dependencies>
+	
 </project>

--- a/MiniCraftLauncher/src/com/mt/minilauncher/Initializer.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/Initializer.java
@@ -54,7 +54,9 @@ public class Initializer {
 		int x = Debug.callConfirmDialog("Warning!", "This will clean all of the launcher's folders.\nYou will lose all game data and all downloaded jars.");
 		
 		if(x == Debug.OK) {
-			Util.purgeDirectory(launcherPath.toFile());
+			Util.purgeDirectory(savesDir.toFile());
+			Util.purgeDirectory(indexPath.toFile());
+			Util.purgeDirectory(jarPath.toFile());
 			touchFoldersAndFiles();
 			LauncherWindow.instance.updateUI();
 		} else {

--- a/MiniCraftLauncher/src/com/mt/minilauncher/LauncherWindow.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/LauncherWindow.java
@@ -274,7 +274,7 @@ public class LauncherWindow {
 						JMenuItem cleanMenu = new JMenuItem("Clean");
 						JMenuItem saveFolderMenu = new JMenuItem("Open Save Folder");
 						JMenuItem modFolderMenu = new JMenuItem("Open Mods Folder");
-						JMenuItem getMD5Menu = new JMenuItem("Get MD5 Hash");
+						
 						
 
 						editMenu.addActionListener(a -> {
@@ -327,29 +327,12 @@ public class LauncherWindow {
 							}
 						});
 						
-						getMD5Menu.addActionListener(a -> {
-							String checksum = "";
-							try {
-								if(vo.isDownloaded) {
-									//TODO: Decouple from GameProvider
-									checksum = com.mt.minigameprovider.services.GetMD5FromJar.getMD5Checksum(Paths.get(Initializer.jarPath.toString(), vo.version + ".jar").toString());
-								} else {
-									checksum = "";
-								}
-							} catch (Exception e1) {
-								// TODO Auto-generated catch block
-								e1.printStackTrace();
-							}
-							
-							if(!checksum.isEmpty()) {
-								Debug.callCrashDialog("MD5 Checksum", new javax.swing.JTextField(checksum), Debug.INF);
-							}
-						});
+						
 						menu.add(editMenu);
 						menu.add(cleanMenu);
 						menu.add(saveFolderMenu);
 						menu.add(modFolderMenu);
-						menu.add(getMD5Menu);
+						
 						menu.show(tree, e.getPoint().x, e.getPoint().y);
 					}
 

--- a/MiniCraftLauncher/src/com/mt/minilauncher/LauncherWindow.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/LauncherWindow.java
@@ -50,15 +50,17 @@ import java.awt.event.ActionEvent;
 import javax.swing.JToolBar;
 import javax.swing.JButton;
 import java.awt.Toolkit;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.ChangeEvent;
 
 public class LauncherWindow {
 
 	public static LauncherWindow instance;
 	public JFrame frmLauncher;
-	private JCheckBoxMenuItem hideLauncherDuringPlayCheckBox;
 	private JTree tree;
 	private JTextArea console;
 	private LauncherWrapper launcherWrapper;
+	private JCheckBoxMenuItem hideLauncherMenuItem;
 	/**
 	 * Launch the application.
 	 */
@@ -168,7 +170,7 @@ public class LauncherWindow {
 		JMenuItem cleanFoldersMenuItem = new JMenuItem("Clean Folders");
 		cleanFoldersMenuItem.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
-				Util.purgeDirectoryButKeepSubDirectories(Initializer.launcherPath.toFile());
+				Initializer.cleanFolders();
 			}
 		});
 		editMenu.add(cleanFoldersMenuItem);
@@ -200,10 +202,11 @@ public class LauncherWindow {
 		});
 		launcherGroup.add(fabricLauncherMenuItem);
 		
-		hideLauncherDuringPlayCheckBox = new JCheckBoxMenuItem("Hide Launcher During Play");
-		hideLauncherDuringPlayCheckBox.setSelected(true);
-		//optionsMenu.add(hideLauncherDuringPlayCheckBox);
-
+		hideLauncherMenuItem = new JCheckBoxMenuItem("Hide Launcher");
+		
+		hideLauncherMenuItem.setSelected(true);
+		optionsMenu.add(hideLauncherMenuItem);
+		
 		JMenu helpMenu = new JMenu("Help");
 		menuBar.add(helpMenu);
 
@@ -355,10 +358,6 @@ public class LauncherWindow {
 		updateUI();
 	}
 
-	public JCheckBoxMenuItem getHideLauncherDuringPlayCheckBox() {
-		return hideLauncherDuringPlayCheckBox;
-	}
-
 	public JTree getTree() {
 		return tree;
 	}
@@ -397,4 +396,7 @@ public class LauncherWindow {
 	
 	
 
+	public JCheckBoxMenuItem getHideLauncherMenuItem() {
+		return hideLauncherMenuItem;
+	}
 }

--- a/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
@@ -1,5 +1,7 @@
 package com.mt.minilauncher.launchwrap;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 
 import com.mt.minilauncher.Initializer;
@@ -10,17 +12,32 @@ public class FabricWrap implements IWrap{
 
 	@Override
 	public void launchJar(String path, String version, LauncherWindow window) {
-//		String vPath = Paths.get(Initializer.savesDir.toString(), version).toString();
-//		String lPath = Initializer.launcherPath.toString();
-//		Thread gameThread = new Thread() {
-//			@Override
-//			public void run() {
-//				System.setProperty("fabric.skipMcProvider", "true");
-//				System.setProperty("fabric.gameJarPath", path);
-//				KnotClient.main(new String[] {"--gameDir", lPath, "--savedir", vPath});
-//			}
-//		};
-//		gameThread.start();
+
+		String vPath = Paths.get(Initializer.savesDir.toString(), version).toString();
+		String lPath = Initializer.launcherPath.toString();
+		File f = new File("FabricBootstrap.jar");
+		if(!f.exists()) {
+			window.getConsole().setText("Failed to use FabricWrap, could not find FabricBootstrap.jar!");
+		} else {
+			try {
+				Process ps = Runtime.getRuntime().exec(new String[] {"java", "-jar", "FabricBootstrap.jar", vPath, path, lPath});
+				
+				//hide launcher
+				window.frmLauncher.setVisible(false);
+				try {
+					ps.waitFor();
+				} catch (InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+				window.frmLauncher.setVisible(true);
+				//end hide launcher
+				
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
 		
 	}
 

--- a/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
@@ -20,6 +20,7 @@ public class FabricWrap implements IWrap{
 			window.getConsole().setText("Failed to use FabricWrap, could not find FabricBootstrap.jar!");
 		} else {
 			try {
+				//FabricBootstrap expects 3 arguments: the version folder, the jar file, and the launcher folder
 				Process ps = Runtime.getRuntime().exec(new String[] {"java", "-jar", "FabricBootstrap.jar", vPath, path, lPath});
 				
 				if(window.getHideLauncherMenuItem().isSelected()) {

--- a/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
@@ -11,17 +11,17 @@ public class FabricWrap implements IWrap{
 
 	@Override
 	public void launchJar(String path, String version, LauncherWindow window) {
-		String vPath = Paths.get(Initializer.savesDir.toString(), version).toString();
-		String lPath = Initializer.launcherPath.toString();
-		Thread gameThread = new Thread() {
-			@Override
-			public void run() {
-				System.setProperty("fabric.skipMcProvider", "true");
-				System.setProperty("fabric.gameJarPath", path);
-				KnotClient.main(new String[] {"--gameDir", lPath, "--savedir", vPath});
-			}
-		};
-		gameThread.start();
+//		String vPath = Paths.get(Initializer.savesDir.toString(), version).toString();
+//		String lPath = Initializer.launcherPath.toString();
+//		Thread gameThread = new Thread() {
+//			@Override
+//			public void run() {
+//				System.setProperty("fabric.skipMcProvider", "true");
+//				System.setProperty("fabric.gameJarPath", path);
+//				KnotClient.main(new String[] {"--gameDir", lPath, "--savedir", vPath});
+//			}
+//		};
+//		gameThread.start();
 		
 	}
 

--- a/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
@@ -5,7 +5,6 @@ import java.nio.file.Paths;
 import com.mt.minilauncher.Initializer;
 import com.mt.minilauncher.LauncherWindow;
 
-import net.fabricmc.loader.launch.knot.KnotClient;
 
 public class FabricWrap implements IWrap{
 

--- a/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/FabricWrap.java
@@ -22,16 +22,21 @@ public class FabricWrap implements IWrap{
 			try {
 				Process ps = Runtime.getRuntime().exec(new String[] {"java", "-jar", "FabricBootstrap.jar", vPath, path, lPath});
 				
-				//hide launcher
-				window.frmLauncher.setVisible(false);
+				if(window.getHideLauncherMenuItem().isSelected()) {
+					window.frmLauncher.setVisible(false);
+				}
+				
 				try {
 					ps.waitFor();
 				} catch (InterruptedException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
 				}
-				window.frmLauncher.setVisible(true);
-				//end hide launcher
+				
+				if(!window.frmLauncher.isVisible()) {
+					window.frmLauncher.setVisible(true);
+				}
+				
 				
 			} catch (IOException e) {
 				// TODO Auto-generated catch block

--- a/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/LauncherWrapper.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/launchwrap/LauncherWrapper.java
@@ -14,9 +14,11 @@ public class LauncherWrapper {
 	LauncherWindow window;
 	String prompt = String.format("[%s] ", LauncherWrapper.class.getSimpleName());
 	
+	
 	public LauncherWrapper(IWrap wrapper, LauncherWindow window) {
 		this.wrapper = wrapper;
 		this.window = window;
+		
 	}
 	
 	public void launch() {
@@ -50,6 +52,5 @@ public class LauncherWrapper {
 	public void setWindow(LauncherWindow window) {
 		this.window = window;
 	}
-	
-	
+
 }


### PR DESCRIPTION
Moves the code from `FabricWrap` to it's own jar, along with the Fabric dependencies. This means when a game closes using `System.exit()` it won't kill the launcher as it's in a separate process. Just like with the `VanillaWrap`.