### PR TITLE
New index xml (Human-readable channel list)

### DIFF
--- a/MiniCraftLauncher/src/com/mt/minilauncher/LauncherWindow.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/LauncherWindow.java
@@ -140,8 +140,7 @@ public class LauncherWindow {
 				cs.setVisible(true);
 				cs.getOkButton().addActionListener(l -> {
 					try {
-						Path filePath = Paths.get(Initializer.indexPath.toString(),
-								String.format("index%d.xml", cs.getList().getSelectedIndex()));
+						Path filePath = Paths.get(Initializer.indexPath.toString(), cs.getList().getSelectedValue().target);
 						Util.downloadUsingNIO(cs.getList().getSelectedValue().channelFile, filePath.toString());
 						DefaultTreeModel dtm = new DefaultTreeModel(XMLConverter.fromXML(filePath.toString()));
 						tree.setModel(dtm);

--- a/MiniCraftLauncher/src/com/mt/minilauncher/objects/ChannelObject.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/objects/ChannelObject.java
@@ -1,6 +1,7 @@
 package com.mt.minilauncher.objects;
 
 import java.io.Serializable;
+import java.util.Random;
 
 public class ChannelObject implements Serializable{
 	/**
@@ -8,14 +9,21 @@ public class ChannelObject implements Serializable{
 	 */
 	private static final long serialVersionUID = 1L;
 	public String channelFile;
+	public String channelName;
 	
 	public ChannelObject(String channelFile) {
+		Random rand = new Random();
 		this.channelFile = channelFile;
+		this.channelName = "Channel " + rand.nextInt(0, 256);
 	}
 
+	public ChannelObject(String channelFile, String channelName) {
+		this.channelFile = channelFile;
+		this.channelName = channelName;
+	}
 	@Override
 	public String toString() {
-		return channelFile;
+		return channelName;
 	}
 	
 	

--- a/MiniCraftLauncher/src/com/mt/minilauncher/objects/ChannelObject.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/objects/ChannelObject.java
@@ -10,16 +10,26 @@ public class ChannelObject implements Serializable{
 	private static final long serialVersionUID = 1L;
 	public String channelFile;
 	public String channelName;
+	public String target;
 	
 	public ChannelObject(String channelFile) {
 		Random rand = new Random();
 		this.channelFile = channelFile;
 		this.channelName = "Channel " + rand.nextInt(0, 256);
+		this.target = "index" + rand.nextInt(0, 256) + ".xml";
 	}
 
 	public ChannelObject(String channelFile, String channelName) {
+		Random rand = new Random();
 		this.channelFile = channelFile;
 		this.channelName = channelName;
+		this.target = "index" + rand.nextInt(0, 256) + ".xml";
+	}
+	
+	public ChannelObject(String channelFile, String channelName, String target) {
+		this.channelFile = channelFile;
+		this.channelName = channelName;
+		this.target = target;
 	}
 	@Override
 	public String toString() {

--- a/MiniCraftLauncher/src/com/mt/minilauncher/windows/ChannelSelector.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/windows/ChannelSelector.java
@@ -151,6 +151,7 @@ public class ChannelSelector extends JDialog {
 				Node urlNode = urlList.item(0);
 				if(urlNode.getNodeType() == Node.ELEMENT_NODE) {
 					Element urlElement = (Element) urlNode;
+					String target = urlElement.getAttribute("target");
 					String url = (urlElement.getTextContent().startsWith("http://") || urlElement.getTextContent().startsWith("https://")) ? urlElement.getTextContent() : "";
 					tempList.add(new ChannelObject(url, indexName));
 				}

--- a/MiniCraftLauncher/src/com/mt/minilauncher/windows/ChannelSelector.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/windows/ChannelSelector.java
@@ -2,15 +2,29 @@ package com.mt.minilauncher.windows;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
 import com.mt.minilauncher.Initializer;
 import com.mt.minilauncher.objects.ChannelObject;
 import com.mt.minilauncher.util.OrderedProperties;
@@ -93,31 +107,62 @@ public class ChannelSelector extends JDialog {
 
 	private void init() {
 		try {
-			Util.downloadUsingNIO("https://github.com/MajickTek/MiniCraftLauncherIndex/raw/main/index.txt", Paths.get(Initializer.indexPath.toString(), "index.txt").toString());
+			Util.downloadUsingNIO("https://github.com/MajickTek/MiniCraftLauncherIndex/raw/main/index.xml",
+					Paths.get(Initializer.indexPath.toString(), "index.xml").toString());
 			buildList();
-		} catch (IOException e) {
+		} catch (IOException | ParserConfigurationException | SAXException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		
-		
+
 	}
 
-	private void buildList() {
-		Path indexPath = Paths.get(Initializer.indexPath.toString(), "index.txt");
-        DefaultListModel<ChannelObject> model = new DefaultListModel<>();
+	private void buildList() throws ParserConfigurationException, SAXException, IOException {
+		Path indexPath = Paths.get(Initializer.indexPath.toString(), "index.xml");
+		DefaultListModel<ChannelObject> model = new DefaultListModel<>();
+
+//        OrderedProperties op = new OrderedProperties();
+//        try {
+//			op.load(new FileInputStream(indexPath.toString()));
+//			op.entrySet().forEach(l -> {
+//				model.add(Integer.parseInt(l.getKey().toString()), new ChannelObject(l.getValue().toString()));
+//			});
+//		} catch (IOException e) {
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
+
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
+		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document doc = db.parse(indexPath.toFile());
 		
-        OrderedProperties op = new OrderedProperties();
-        try {
-			op.load(new FileInputStream(indexPath.toString()));
-			op.entrySet().forEach(l -> {
-				model.add(Integer.parseInt(l.getKey().toString()), new ChannelObject(l.getValue().toString()));
-			});
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		doc.getDocumentElement().normalize();
+		ArrayList<ChannelObject> tempList = new ArrayList<>();
+		
+		NodeList indexList = doc.getElementsByTagName("index");
+		for(int i = 0; i < indexList.getLength(); i++) {
+			Node indexNode = indexList.item(i);
+			if(indexNode.getNodeType() == Node.ELEMENT_NODE) {
+				Element indexElement = (Element) indexNode;
+				String indexName = indexElement.getAttribute("name");
+				NodeList urlList = indexElement.getElementsByTagName("url");
+				Node urlNode = urlList.item(0);
+				if(urlNode.getNodeType() == Node.ELEMENT_NODE) {
+					Element urlElement = (Element) urlNode;
+					String url = (urlElement.getTextContent().startsWith("http://") || urlElement.getTextContent().startsWith("https://")) ? urlElement.getTextContent() : "";
+					tempList.add(new ChannelObject(url, indexName));
+				}
+			}
 		}
-        
+		
+		ChannelObject[] objects = new ChannelObject[tempList.size()];
+		objects = tempList.toArray(objects);
+		
+		for(int i = 0; i < objects.length; i++) {
+			model.add(i, objects[i]);
+		}
 		list.setModel(model);
 		list.updateUI();
 	}
@@ -125,9 +170,11 @@ public class ChannelSelector extends JDialog {
 	public JList<ChannelObject> getList() {
 		return list;
 	}
+
 	public JButton getOkButton() {
 		return okButton;
 	}
+
 	public JButton getCancelButton() {
 		return cancelButton;
 	}

--- a/MiniCraftLauncher/src/com/mt/minilauncher/windows/ChannelSelector.java
+++ b/MiniCraftLauncher/src/com/mt/minilauncher/windows/ChannelSelector.java
@@ -121,47 +121,37 @@ public class ChannelSelector extends JDialog {
 		Path indexPath = Paths.get(Initializer.indexPath.toString(), "index.xml");
 		DefaultListModel<ChannelObject> model = new DefaultListModel<>();
 
-//        OrderedProperties op = new OrderedProperties();
-//        try {
-//			op.load(new FileInputStream(indexPath.toString()));
-//			op.entrySet().forEach(l -> {
-//				model.add(Integer.parseInt(l.getKey().toString()), new ChannelObject(l.getValue().toString()));
-//			});
-//		} catch (IOException e) {
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
 		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 		DocumentBuilder db = dbf.newDocumentBuilder();
 		Document doc = db.parse(indexPath.toFile());
-		
+
 		doc.getDocumentElement().normalize();
 		ArrayList<ChannelObject> tempList = new ArrayList<>();
-		
+
 		NodeList indexList = doc.getElementsByTagName("index");
-		for(int i = 0; i < indexList.getLength(); i++) {
+		for (int i = 0; i < indexList.getLength(); i++) {
 			Node indexNode = indexList.item(i);
-			if(indexNode.getNodeType() == Node.ELEMENT_NODE) {
+			if (indexNode.getNodeType() == Node.ELEMENT_NODE) {
 				Element indexElement = (Element) indexNode;
 				String indexName = indexElement.getAttribute("name");
 				NodeList urlList = indexElement.getElementsByTagName("url");
 				Node urlNode = urlList.item(0);
-				if(urlNode.getNodeType() == Node.ELEMENT_NODE) {
+				if (urlNode.getNodeType() == Node.ELEMENT_NODE) {
 					Element urlElement = (Element) urlNode;
 					String target = urlElement.getAttribute("target");
-					String url = (urlElement.getTextContent().startsWith("http://") || urlElement.getTextContent().startsWith("https://")) ? urlElement.getTextContent() : "";
+					String url = (urlElement.getTextContent().startsWith("http://")
+							|| urlElement.getTextContent().startsWith("https://")) ? urlElement.getTextContent() : "";
 					tempList.add(new ChannelObject(url, indexName));
 				}
 			}
 		}
-		
+
 		ChannelObject[] objects = new ChannelObject[tempList.size()];
 		objects = tempList.toArray(objects);
-		
-		for(int i = 0; i < objects.length; i++) {
+
+		for (int i = 0; i < objects.length; i++) {
 			model.add(i, objects[i]);
 		}
 		list.setModel(model);


### PR DESCRIPTION
Adds an `index.xml` to the `MiniCraftLauncherIndex` repo. Leaves the original `index.txt` intact for older launcher versions.

Now the index files get a display name and a non-random download target (filename).

Instead of just seeing a list of URLs in the channel selector, you see a list of names such as "Release", "Standalone Mods", etc.
